### PR TITLE
Fix missing "rake" in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ bundle && yarn && rake db:create db:schema:load
 bundle exec rails server
 
 [new tab]
-cd server && bundle exec game:run
+cd server && bundle exec rake game:run
 
 [new tab]
 cd client


### PR DESCRIPTION
When trying to run the game, I encountered the error:
```bundler: command not found: game:run```

This was fixed by including `rake` in the command