### PR TITLE
Update readme instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,16 +33,19 @@ You connect to the server via websockets - there's a sample client and utility c
 You need to run 3 processes: the server, the client, and the game.
 
 ```
+# Starting the server
 cd server
 bundle && yarn && rake db:create db:schema:load
-bundle exec rails server
+bundle exec rails server --port 8080
 
 [new tab]
+# Starting the game
 cd server && bundle exec rake game:run
 
 [new tab]
+# Starting the client
 cd client
-bundle && yarn
+bundle
 bundle exec ruby runner.rb
 ```
 


### PR DESCRIPTION
Running the commands in the readme results in the server starting on
port 3000 and the client expects it to be on 8080, so we get the error:

> Doh - disconnected - no snek running at localhost:8080

I've updated the instructions to set the port for the server, there is also a
Procfile which the instructions don't use, it could be a good idea to have a
single Procfile in the base directory that starts all 3 processes.

Also the client doesn't use node, so no need to install packages via yarn.