### PR TITLE
Document the run game rake task

### DIFF
--- a/server/lib/tasks/game.rake
+++ b/server/lib/tasks/game.rake
@@ -1,3 +1,4 @@
+desc 'Start the snek game server'
 namespace :game do
   task :run => [:environment] do
     $redis.flushdb


### PR DESCRIPTION
Adding the documentation means it comes up in the list when running
`rake -T` making it easier to find :)